### PR TITLE
`is_last` should not be checked for`ValueFunction`

### DIFF
--- a/diffuser/models/temporal.py
+++ b/diffuser/models/temporal.py
@@ -183,8 +183,8 @@ class ValueFunction(nn.Module):
                 Downsample1d(dim_out)
             ]))
 
-            if not is_last:
-                horizon = horizon // 2
+            # if not is_last:
+            horizon = horizon // 2
 
         mid_dim = dims[-1]
         mid_dim_2 = mid_dim // 2


### PR DESCRIPTION
Thanks for your wonderful project. 

I think, here, `is_last` should not be checked for `ValueFunction`, since there's no `nn.Identity()` here for the last block:

```python
        for ind, (dim_in, dim_out) in enumerate(in_out):
            is_last = ind >= (num_resolutions - 1)

            self.blocks.append(nn.ModuleList([
                ResidualTemporalBlock(dim_in, dim_out, kernel_size=5, embed_dim=time_dim, horizon=horizon),
                ResidualTemporalBlock(dim_out, dim_out, kernel_size=5, embed_dim=time_dim, horizon=horizon),
                Downsample1d(dim_out)
            ]))

            if not is_last: # Should delete this line
                horizon = horizon // 2
```

Otherwise, the dimension may not be correctly handled:

e.g. For `horizon=32` and `dim_mults=(1, 4, 8)`, a dimension-mismatch error would appear:
```shell
RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x96 and 160x64)
```

```python
        for ind, (dim_in, dim_out) in enumerate(in_out):
            is_last = ind >= (num_resolutions - 1)

            self.blocks.append(nn.ModuleList([
                ResidualTemporalBlock(dim_in, dim_out, kernel_size=5, embed_dim=time_dim, horizon=horizon),
                ResidualTemporalBlock(dim_out, dim_out, kernel_size=5, embed_dim=time_dim, horizon=horizon),
                Downsample1d(dim_out)
            ]))

            horizon = horizon // 2
```

This bug will not appear when horizon is small (0 // 2 =0), but will appear for large horizon.